### PR TITLE
Make Mixpanel use HTTPS by default

### DIFF
--- a/lib/integrations/mixpanel-node/index.js
+++ b/lib/integrations/mixpanel-node/index.js
@@ -24,6 +24,7 @@ var Mixpanel = module.exports = integration('Mixpanel')
 Mixpanel.prototype.initialize = function () {
     // this.options.increments = lowercase(this.options.increments);
     var options = this.options;
+    options.protocol = 'https';
     global.mixpanel = MixpanelLib.init(options.token, options);
 };
 


### PR DESCRIPTION
Connects to: https://github.com/resin-io-playground/node.analytics/issues/4